### PR TITLE
fix: patch original Tresorit .desktop files on-the-fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ without the worry about it being a dynamically-linked, self-updating binary.
    && sh tresorit_installer.run && rm tresorit_installer.run
    ```
 1. Build FHS env: `NIXPKGS_ALLOW_UNFREE=1 nix build --impure .#default`
-1. Patch Tresorit .desktop files: `./patch.sh`
-   <details>
-     <summary>details on patching</summary>
+1. Create Tresorit FHS launcher script: `./create_launcher.sh` (requires `bash`)
+1. Launch `Tresorit FHS` from your favorite app launcher and sign in.
 
-     - creates an FHS env-based Tresorit launcher for desktop environments
-     - registers Tresorit launcher as autostart application
-     - updates desktop environment (.desktop) files to respect FHS env
-   </details>
+Done 🎉.
 
-Done 🎉
+<details>
+<summary>Quick troubleshooting</summary>
+
+- service status: `systemctl --user status app-tresorit\\x2dfhs@autostart.service`
+- logs: `journalctl --user -u app-tresorit\\x2dfhs@autostart.service`
+</details>

--- a/create_launcher.sh
+++ b/create_launcher.sh
@@ -13,6 +13,16 @@ die() {
     exit 1
 }
 
+launcher_script="${HOME}/.local/share/tresorit/tresorit_fhs_launcher.sh"
+if [ -f "${HOME}/.local/share/tresorit/tresorit_launcher.sh" ]; then
+    launcher_script="${HOME}/.local/share/tresorit/tresorit_launcher.sh"
+fi
+launch_cmd=$(grep "tresorit --hidden" "${launcher_script}")
+launch_cmd=${launch_cmd%" &"}
+stop_cmd=$(echo $launch_cmd | sed 's/tresorit \-\-hidden/tresorit-cli stop/')
+printf "Stopping Tresorit FHS...\n"
+eval "${stop_cmd}"
+
 self_path="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
 out_path="${self_path}/result/bin/tresorit-fhs"
 
@@ -33,7 +43,7 @@ cat > "tresorit_fhs_launcher.sh" <<EOF
 #!/usr/bin/env bash
 ${HOME}/.local/share/tresorit/patch.sh
 printf "Starting Tresorit within FHS environment...\n"
-${tresorit_fhs_shell} -c "${HOME}/.local/share/tresorit/tresorit --hidden" &
+${tresorit_fhs_shell} -c "${HOME}/.local/share/tresorit/tresorit --hidden" > /dev/null 2>&1 &
 printf "Done.\n"
 EOF
 chmod +x "tresorit_fhs_launcher.sh"
@@ -43,7 +53,7 @@ printf "Copying & running Tresorit application & autostart patching script...\n"
 cp ./patch.sh ${HOME}/.local/share/tresorit/patch.sh
 ${HOME}/.local/share/tresorit/patch.sh
 
-printf "Launching Tresorit FHS daemon..."
+printf "Launching Tresorit FHS daemon...\n"
 "${HOME}/.local/share/tresorit/tresorit_fhs_launcher.sh"
 
 printf "Done 🚀\n"

--- a/create_launcher.sh
+++ b/create_launcher.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+err_report() {
+    echo "Error on line $(caller)" >&2
+    awk 'NR>L-4 && NR<L+4 { printf "%-5d%3s%s\n",NR,(NR==L?">>>":""),$0 }' L=$1 $0
+}
+trap 'err_report $LINENO' ERR
+
+die() {
+    printf "\n⚠️ ${1}\n\nExiting.\n"
+    exit 1
+}
+
+self_path="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
+out_path="${self_path}/result/bin/tresorit-fhs"
+
+if ! [ -h "${out_path}" ]; then
+    die "The output of \"nix build\" could not be found at \"${out_path}\"."
+fi
+
+if [ -f "${HOME}/.local/share/tresorit/tresorit_launcher.sh" ]; then
+    printf "Found old installation (2025-09-14 or older), cleaning it up.\n"
+    rm "${HOME}/.local/share/tresorit/tresorit_launcher.sh" # succeeded by "tresorit_fhs_launcher.sh"
+    cp ${HOME}/.local/share/applications/tresorit.desktop.bk \
+       ${HOME}/.local/share/applications/tresorit.desktop # restore original file, thus triggering patching script
+fi
+
+printf "Creating Tresorit launcher...\n"
+tresorit_fhs_shell=$(readlink -f "${out_path}")
+cat > "tresorit_fhs_launcher.sh" <<EOF
+#!/usr/bin/env bash
+${HOME}/.local/share/tresorit/patch.sh
+printf "Starting Tresorit within FHS environment...\n"
+${tresorit_fhs_shell} -c "${HOME}/.local/share/tresorit/tresorit --hidden" &
+printf "Done.\n"
+EOF
+chmod +x "tresorit_fhs_launcher.sh"
+mv "tresorit_fhs_launcher.sh" "${HOME}/.local/share/tresorit/tresorit_fhs_launcher.sh"
+
+printf "Copying & running Tresorit application & autostart patching script...\n"
+cp ./patch.sh ${HOME}/.local/share/tresorit/patch.sh
+${HOME}/.local/share/tresorit/patch.sh
+
+printf "Launching Tresorit FHS daemon..."
+"${HOME}/.local/share/tresorit/tresorit_fhs_launcher.sh"
+
+printf "Done 🚀\n"

--- a/patch.sh
+++ b/patch.sh
@@ -49,6 +49,7 @@ else
     cp "${HOME}/${de_app_registry_relpath}/${tresorit_desktop}" \
        "${HOME}/${tresorit_autostart_relpath}.bk"
 fi
+sed -i 's/^/# /' "${HOME}/${tresorit_autostart_relpath}.bk"
 
 printf "Patching Tresorit startup config...\n"
 if ! [ -f "${HOME}/${tresorit_autostart_relpath}.bk" ]; then
@@ -56,6 +57,7 @@ if ! [ -f "${HOME}/${tresorit_autostart_relpath}.bk" ]; then
 fi
 cp "${HOME}/${tresorit_autostart_relpath}.bk" \
    "${HOME}/${de_autostart_relpath}/${tresorit_fhs_desktop}"
+sed -i 's/^# //' "${HOME}/${de_autostart_relpath}/${tresorit_fhs_desktop}"
 sed -i \
     "s|^Name=Tresorit$|Name=Tresorit FHS|" \
     "${HOME}/${de_autostart_relpath}/${tresorit_fhs_desktop}"

--- a/patch.sh
+++ b/patch.sh
@@ -13,70 +13,38 @@ err_exit() {
     exit 1
 }
 
-out_relpath="result/bin/tresorit-fhs"
-tresorit_launcher_file="tresorit_launcher.sh"
-tresorit_relpath=".local/share/tresorit"
-de_autostart_relpath=".config/autostart"
-de_app_registry_relpath=".local/share/applications"
-tresorit_desktop="tresorit.desktop"
-tresorit_fhs_desktop="tresorit-fhs.desktop"
-tresorit_autostart_relpath="${de_autostart_relpath}/${tresorit_desktop}"
-self_path="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
-out_path="${self_path}/${out_relpath}"
-
-if ! [ -h "${out_path}" ]; then
-    err_exit "The output of \"nix build\" could not be found at \"${out_relpath}\"."
+tresorit_fhs_changed="false"
+if [ -f "${HOME}/.local/share/applications/tresorit.desktop" ]; then
+    printf "Patch Tresorit application config...\n"
+    mv "${HOME}/.local/share/applications/tresorit.desktop" \
+       "${HOME}/.local/share/applications/tresorit.desktop.bk"
+    sed -i 's/^/# /' "${HOME}/.local/share/applications/tresorit.desktop.bk"
+    cp "${HOME}/.local/share/applications/tresorit.desktop.bk" \
+       "${HOME}/.local/share/applications/tresorit-fhs.desktop"
+    sed -i 's/^# //' "${HOME}/.local/share/applications/tresorit-fhs.desktop"
+    sed -i \
+        "s|^Name=Tresorit$|Name=Tresorit FHS|" \
+        "${HOME}/.local/share/applications/tresorit-fhs.desktop"
+    sed -i \
+        "s|^Exec=.*$|Exec=${HOME}/.local/share/tresorit/tresorit_fhs_launcher.sh|" \
+        "${HOME}/.local/share/applications/tresorit-fhs.desktop"
+    tresorit_fhs_changed="true"
 fi
 
-printf "Creating Tresorit launcher...\n"
-tresorit_fhs_shell=$(readlink -f "${out_path}")
-cat > "${tresorit_launcher_file}" <<EOF
-printf "Starting Tresorit within FHS environment...\n"
-${tresorit_fhs_shell} -c "${HOME}/${tresorit_relpath}/tresorit --hidden" &
-printf "Done.\n"
-EOF
-chmod +x "${tresorit_launcher_file}"
-mv "${tresorit_launcher_file}" "${HOME}/${tresorit_relpath}/"
-
-if ! [ -d "${HOME}/${de_autostart_relpath}" ]; then
-    mkdir "${HOME}/${de_autostart_relpath}"
+if ! [ -d "${HOME}/.config/autostart" ]; then
+    printf "Create ~/.config/autostart exists...\n"
+    mkdir "${HOME}/.config/autostart"
 fi
-if [ -f "${HOME}"/${tresorit_autostart_relpath} ]; then
-    printf "Removing Tresorit's broken startup config...\n"
-    mv "${HOME}/${tresorit_autostart_relpath}" \
-       "${HOME}/${tresorit_autostart_relpath}.bk"
-else
-    cp "${HOME}/${de_app_registry_relpath}/${tresorit_desktop}" \
-       "${HOME}/${tresorit_autostart_relpath}.bk"
-fi
-sed -i 's/^/# /' "${HOME}/${tresorit_autostart_relpath}.bk"
 
-printf "Patching Tresorit startup config...\n"
-if ! [ -f "${HOME}/${tresorit_autostart_relpath}.bk" ]; then
-    err_exit "Expected to find \"${tresorit_desktop}.bk\", but it is not present."
+if [ -f "${HOME}"/.config/autostart/tresorit.desktop ]; then
+    printf "Disable Tresorit's broken startup config...\n"
+    mv "${HOME}/.config/autostart/tresorit.desktop" \
+       "${HOME}/.config/autostart/tresorit.desktop.bk"
+    sed -i 's/^/# /' "${HOME}/.config/autostart/tresorit.desktop.bk"
 fi
-cp "${HOME}/${tresorit_autostart_relpath}.bk" \
-   "${HOME}/${de_autostart_relpath}/${tresorit_fhs_desktop}"
-sed -i 's/^# //' "${HOME}/${de_autostart_relpath}/${tresorit_fhs_desktop}"
-sed -i \
-    "s|^Name=Tresorit$|Name=Tresorit FHS|" \
-    "${HOME}/${de_autostart_relpath}/${tresorit_fhs_desktop}"
-sed -i \
-    "s|^Exec=.*$|Exec=${HOME}/${tresorit_relpath}/${tresorit_launcher_file}|" \
-    "${HOME}/${de_autostart_relpath}/${tresorit_fhs_desktop}"
 
-printf "Patching Tresorit application config...\n"
-if [ -f "${HOME}/${de_app_registry_relpath}/${tresorit_desktop}" ]; then
-    mv "${HOME}/${de_app_registry_relpath}/${tresorit_desktop}" \
-       "${HOME}/${de_app_registry_relpath}/${tresorit_desktop}.bk"
+if ! [ -f "${HOME}/.config/autostart/tresorit-fhs.desktop" ] || [ ${tresorit_fhs_changed} == "true" ]; then
+    printf "Register Tresorit FHS autostart config...\n"
+    cp "${HOME}/.local/share/applications/tresorit-fhs.desktop" \
+       "${HOME}/.config/autostart/tresorit-fhs.desktop"
 fi
-cp "${HOME}/${de_app_registry_relpath}/${tresorit_desktop}.bk" \
-   "${HOME}/${de_app_registry_relpath}/${tresorit_fhs_desktop}"
-sed -i \
-    "s|^Name=Tresorit$|Name=Tresorit FHS|" \
-    "${HOME}/${de_app_registry_relpath}/${tresorit_fhs_desktop}"
-sed -i \
-    "s|^Exec=.*$|Exec=${HOME}/${tresorit_relpath}/${tresorit_launcher_file}|" \
-    "${HOME}/${de_app_registry_relpath}/${tresorit_fhs_desktop}"
-
-printf "Done.\n"


### PR DESCRIPTION
Every time Tresorit updates itself, it writes .desktop files so it can be detected by the app launcher and autostarts during login. This creates a conflict with the patched Tresorit FHS .desktop files. To resolve this issue, during the launch of Tresorit FHS, a small patching script is run that detects original .desktop files and patches them on-the-fly.

Note for reviewer:
- [x] upgrade existing installation & verify (back it up first)
- [ ] create release once PR is merged